### PR TITLE
Adding response error

### DIFF
--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -71,6 +71,10 @@ class Transaction implements TransactionInterface
         curl_setopt($request_handle, CURLOPT_CUSTOMREQUEST, 'POST');
         curl_setopt($request_handle, CURLOPT_POSTFIELDS, $payload);
         $result = curl_exec($request_handle);
+       
+        if ($result === false) 
+            $result = curl_error($request_handle);
+        
         return new TransactionResponse($result);
     }
 
@@ -103,6 +107,10 @@ class Transaction implements TransactionInterface
         curl_setopt($request_handle, CURLOPT_CUSTOMREQUEST, 'PUT');
         curl_setopt($request_handle, CURLOPT_POSTFIELDS, $payload);
         $result = curl_exec($request_handle);
+        
+        if ($result === false) 
+            $result = curl_error($request_handle);
+        
         return new TransactionResponse($result);
     }
 
@@ -128,6 +136,10 @@ class Transaction implements TransactionInterface
             'Authorization: ' . $this->config->getBearerToken()
         ]);
         $result = curl_exec($request_handle);
+        
+        if ($result === false) 
+            $result = curl_error($request_handle);
+        
         return new TransactionResponse($result);
     }
 }


### PR DESCRIPTION
Estas modificações irão permitir que erros também sejam mostrados no TransactionResponse  em caso de alguma falha na requisição do Curl.
Actualmente em caso de erro com a requisição , o TransactionResponse  fica vazio.